### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,7 @@
 name: "Dependabot Automerge - Action"
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/mpwg/AllesTeurer/security/code-scanning/4](https://github.com/mpwg/AllesTeurer/security/code-scanning/4)

To adhere to the principle of least privilege, add an explicit `permissions` configuration to the workflow. Since the workflow uses automerge on pull requests, it needs `contents: read` (for repository content access) and `pull-requests: write` (to merge PRs and modify PR state). Add the following block:

```yaml
permissions:
  contents: read
  pull-requests: write
```

This block should be placed at the top-level of the workflow file (immediately after the `name:` entry and before the `on:` block), ensuring all jobs inherit these minimal permissions, unless overridden at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
